### PR TITLE
Update mocha to v5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,20 +7,20 @@
   "license": "MIT",
   "main": "lib",
   "scripts": {
-    "test": "mocha  --compilers js:babel-register test",
+    "test": "mocha --require babel-core/register test",
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-core": "^6.26.3",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.9.0",
     "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.1",
-    "mocha": "^2.5.3",
+    "mocha": "^5.2.0",
     "unexpected": "^10.13.3"
   }
 }


### PR DESCRIPTION
This PR updates the Mocha test runner to the latest version. Inline comments about specific changes. Also happy to update ESLint and Babel in other PRs as well if you're interested.