### PR TITLE
Update babel to v7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,7 @@
 {
-  "presets": ["stage-0", "es2015"],
+  "presets": [
+    "@babel/preset-env"
+  ],
   "plugins": [
     "add-module-exports"
   ]

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
   "license": "MIT",
   "main": "lib",
   "scripts": {
-    "test": "mocha --require babel-core/register test",
+    "test": "mocha --require @babel/register test",
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
   "devDependencies": {
-    "babel-cli": "^6.9.0",
-    "babel-core": "^6.26.3",
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-0": "^6.5.0",
     "eslint": "^2.11.1",
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.1",


### PR DESCRIPTION
This PR updates to build with Babel v7. The update was mostly automated with [babel-upgrade](https://github.com/babel/babel-upgrade). 

Before upgrading, I also noticed that removing the stage-0 preset from `.babelrc` and running `npm run build` successfully built this library, so I don't think the experimental syntax features of the stage-0 preset are used/needed in this project. Switching to [@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env) will be a simpler way to build with Babel moving forward.

Let me know your thoughts and if there's anything else I should be considering here. Thanks! 😄 