### PR TITLE
Added check to add and del

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,7 @@ export default function (input, opts = {}) {
   }
 
   function del(line) {
+    if (!file) return;
     current.changes.push({
       type: 'del',
       del: true,
@@ -88,6 +89,7 @@ export default function (input, opts = {}) {
   }
 
   function add(line) {
+    if (!file) return;
     current.changes.push({
       type: 'add',
       add: true,


### PR DESCRIPTION
The `normal` function checks whether the line is in the context of a file.
For example, Mercurial includes some information about the commit itself before starting the actual diff.
However, the `add` and `del` functions did not do this check.
This is problematic when:
- There is content preceding the actual diff and
- This content happens to have lines which start with a `-` or a `+`

Example:
```
# HG changeset patch
# User Me <me@example.com>
# Date <some date>
#      <some timestamp>
# Branch my-branch
# Node ID <some commit hash>
# Parent  <some other commit hash>
This is a very nice commit, in which I
- Added feature 1
- Fixed all the bugs
- Did more awesome stuff.
```

This commit just adds the same check to `add` and `del`.